### PR TITLE
Allow Node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "author": "CKSource (http://cksource.com/)",
   "homepage": "https://market.strapi.io/plugins/@ckeditor-strapi-plugin-ckeditor",
   "engines": {
-    "node": ">=14.19.1 <=16.x.x",
+    "node": ">=14.19.1 <=18.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
[Strapi supports Node 18](https://github.com/strapi/strapi/blob/main/package.json#L114), so I opened a PR so that your plugin matches this. Otherwise Strapi users on node 18 aren't able to install your plugin