### PR TITLE
fix: add 'options.' prefix to maxLengthCharacters

### DIFF
--- a/admin/src/components/CKEditorInput/index.js
+++ b/admin/src/components/CKEditorInput/index.js
@@ -26,8 +26,8 @@ const CKEditorInput = ({
 }) => {
   const [ editorInstance, setEditorInstance ] = useState(false);
   const { formatMessage } = useIntl();
-  const maxLength = attribute.maxLengthCharacters;
-  const configurator = new Configurator( { options: attribute.options, maxLength } );
+  const { maxLengthCharacters:maxLength , ...options } = attribute.options;
+  const configurator = new Configurator( { options, maxLength } );
   const editorConfig = configurator.getEditorConfig();
 
   const wordCounter = useRef(null);

--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -107,7 +107,7 @@ export default {
               // We want to apply this to the number of characters in the editor,
               // hence – a unique name.
               {
-                name: 'maxLengthCharacters',
+                name: 'options.maxLengthCharacters',
                 type: 'checkbox-with-number-field',
                 intlLabel: {
                   id: 'ckeditor.maxLength.label',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckeditor/strapi-plugin-ckeditor",
-  "version": "0.0.4",
+  "version": "0.0.5-fix",
   "description": "CKEditor 5 custom field for Strapi.",
   "strapi": {
     "name": "ckeditor",


### PR DESCRIPTION
From Strapi v4.5.3 is mandatory to use the `options.` prefix on the custom field options.
This solve the problem with last version of Strapi when using CKEditor https://github.com/strapi/strapi/issues/15048