### PR TITLE
add README usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ or:
 yarn build
 ```
 
+## <a id="usage"></a>📖 Usage
+
+This section covers the way how to use the plugin.
+
+To add a CKEditor field to a collection type or single type, follow these steps:
+
+1. Click the "Add another field" button to open the component selection modal.
+2. In the top right corner of the modal, click "Custom".
+3. Select "CKEditor" from the list of options.
+4. Configure any additional options as needed, and click "Save" to add the CKEditor field to your collection type or single type.
+
 ## <a id="contributing"></a>🛠 Contributing
 
 This section covers the way how to configure your environment if you want to contribute to this package.


### PR DESCRIPTION
The purpose of this PR is to add a section to the README that teaches users how to use the plugin in their Strapi application. I had some trouble figuring it out on my own, so I thought it would be helpful to share the knowledge gained to help other users find a solution more quickly. I hope this addition makes the documentation clearer and more useful for anyone looking to use the plugin.