### PR TITLE
fix(style): Prevent dropdown panel to be hidden by Strapi left sidebar

### DIFF
--- a/admin/src/components/CKEditorInput/styles/common.js
+++ b/admin/src/components/CKEditorInput/styles/common.js
@@ -111,4 +111,8 @@ export const style = css`
       }
     }
   }
+  // Fix: Prevent dropdown panel to be hidden by Strapi left sidebar
+  :root {
+    --ck-toolbar-dropdown-max-width: 40vw;
+  }
 `;


### PR DESCRIPTION
Fixes issue #54 
