### PR TITLE
Feat: add "target: blank" option to links

### DIFF
--- a/admin/src/components/CKEditorInput/Configurator.js
+++ b/admin/src/components/CKEditorInput/Configurator.js
@@ -90,6 +90,18 @@ const CKEDITOR_BASE_CONFIG_FOR_PRESETS = {
         'toggleTableCaption'
       ]
     },
+    link: {
+      decorators: {
+        openInNewTab: {
+          mode: 'manual',
+          label: 'Open in a new tab',
+          attributes: {
+            target: '_blank',
+            rel: 'noopener noreferrer'
+          }
+        }
+      }
+    }
   },
 
   standard: {
@@ -161,6 +173,18 @@ const CKEDITOR_BASE_CONFIG_FOR_PRESETS = {
         'toggleTableCaption'
       ]
     },
+    link: {
+      decorators: {
+        openInNewTab: {
+          mode: 'manual',
+          label: 'Open in a new tab',
+          attributes: {
+            target: '_blank',
+            rel: 'noopener noreferrer'
+          }
+        }
+      }
+    }
   },
 
   rich: {
@@ -331,6 +355,18 @@ const CKEDITOR_BASE_CONFIG_FOR_PRESETS = {
       columns: 5,
       documentColors: 10,
     },
+    link: {
+      decorators: {
+        openInNewTab: {
+          mode: 'manual',
+          label: 'Open in a new tab',
+          attributes: {
+            target: '_blank',
+            rel: 'noopener noreferrer'
+          }
+        }
+      }
+    }
   }
 };
 


### PR DESCRIPTION
This PR adds a "open link in new tab" feature as documented here https://ckeditor.com/docs/ckeditor5/latest/features/link.html#adding-target-and-rel-attributes-to-external-links
by adding manual decorators to the configs.