### PR TITLE
Update node engine to use LTS versions 18 (and soon 20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "author": "CKSource (http://cksource.com/)",
   "homepage": "https://market.strapi.io/plugins/@ckeditor-strapi-plugin-ckeditor",
   "engines": {
-    "node": ">=14.19.1 <=18.x.x",
+    "node": ">=18.x.x <=20.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
With Active LTS starting for v20 the 24th of October, it would be good to update the engine config in package.json. This way we won't run into an incompatibility error when install the package. Also since last September v16 is EOL. Closes: #81

```bash
error The engine "node" is incompatible with this module. Expected version ">=14.19.1 <=18.x.x". Got "20.5.1"
error Found incompatible module.
```

**Node releases info**  
https://nodejs.dev/en/about/releases/  
 

![image](https://github.com/ckeditor/strapi-plugin-ckeditor/assets/31662805/f136f9ba-93f9-47af-a1c7-c77d691413e3)