### PR TITLE
Fix: Prevent crash when the custom field's value is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.0.2 (September 20, 2024)
+
+### Release highlights
+
+This is a patch release that resolves an issue that resulted in a crash after removing the content from the editor. The issue was caused by the fact that after releasing Strapi 5.0.0, the custom field's `value` property becomes `null` when the editor is empty.
+
+Check out the highlights of the original v1.0.0 release.
+
+### Bug fixes
+* Prevent passing `null` as the editor data to prevent the crash.
+
 ## 1.0.1 (September 19, 2024)
 
 ### Release highlights

--- a/admin/src/components/CKEditorInput/index.jsx
+++ b/admin/src/components/CKEditorInput/index.jsx
@@ -76,7 +76,7 @@ const CKEditorInput = ( props ) => {
         <CKEditor
           editor={ ClassicEditor }
           disabled={ disabled }
-          data={ value }
+          data={ value ?? '' }
           onReady={ ( editor ) => {
             const wordCountPlugin = editor.plugins.get( 'WordCount' );
             const wordCountWrapper = wordCounter.current;
@@ -89,7 +89,6 @@ const CKEditorInput = ( props ) => {
           }}
           onChange={ ( event, editor ) => {
             const data = editor.getData();
-
             onChange( { target: { name, value: data } } );
 
             const wordCountPlugin = editor.plugins.get( 'WordCount' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckeditor/strapi-plugin-ckeditor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CKEditor 5 - Official Integration for Strapi",
   "strapi": {
     "name": "ckeditor",


### PR DESCRIPTION
This is a patch release that resolves an issue that resulted in a crash after removing the content from the editor. The issue was caused by the fact that after releasing Strapi 5.0.0, the custom field's `value` property becomes `null` when the editor is empty.

Check out the highlights of the original v1.0.0 release.

### Bug fixes
* Prevent passing `null` as the editor data to prevent the crash.