### PR TITLE
feat(#146): allow loading license from server config

### DIFF
--- a/admin/src/api/license.js
+++ b/admin/src/api/license.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const licenseRequests = {
+  getLicense: async () => await axios.get(`/ckeditor/config`)
+}
+
+export default licenseRequests;

--- a/admin/src/components/CKEditorProvider/index.jsx
+++ b/admin/src/components/CKEditorProvider/index.jsx
@@ -1,5 +1,6 @@
-import { memo, useEffect } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useCKEditorCloud } from '@ckeditor/ckeditor5-react';
+import licenseRequests from '../../api/license';
 
 const CKEditorProvider = ( {
   attribute,
@@ -57,4 +58,47 @@ const CKEditorProvider = ( {
   )
 }
 
-export default memo( CKEditorProvider );
+const MemoizedCKEditorProvider = memo( CKEditorProvider );
+
+const CKEditorProviderWrapper = ({
+  attribute,
+  name,
+  disabled = false,
+  labelAction = null,
+  required = false,
+  description = null,
+  error = null,
+  intlLabel,
+}) => {
+  const { options } = attribute;
+
+  const [licenseKey, setLicenseKey] = useState(options?.licenseKey);
+
+  useEffect(() => {
+    licenseRequests.getLicense().then((response) => {
+      const licenseKeyFromServer = response.data?.ckeditor?.licenseKey;
+      if (licenseKeyFromServer) {
+        setLicenseKey(licenseKeyFromServer);
+      }
+    })
+  }, []);
+
+  if (!licenseKey) {
+    return <div>Loading License Key...</div>
+  }
+
+  return (
+    <MemoizedCKEditorProvider
+      attribute={{ ...attribute, options: { ...options, licenseKey } }}
+      name={ name }
+      disabled={ disabled }
+      labelAction={ labelAction }
+      required={ required }
+      description={ description }
+      error={ error }
+      intlLabel={ intlLabel }
+    />
+  );
+}
+
+export default CKEditorProviderWrapper;

--- a/server/controllers/config.js
+++ b/server/controllers/config.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+  index(ctx) {
+    ctx.body = {
+      ckeditor: {
+        licenseKey: process.env.CKEDITOR_LICENSE_KEY || "",
+      }
+    }
+  },
+};

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  config: require("./config"),
+};

--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,12 @@
 
 const register = require( './register' );
 
+const routes = require("./routes");
+const controllers = require("./controllers");
+
 module.exports = {
   register,
+
+  controllers,
+  routes,
 };

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -1,0 +1,13 @@
+module.exports = {
+  type: "admin",
+  routes: [
+    {
+      method: "GET",
+      path: "/config",
+      handler: "config.index",
+      config: {
+        policies: [],
+      },
+    },
+  ],
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  admin: require("./admin"),
+};


### PR DESCRIPTION
Allow loading license from server config, so that:

- Don't need to hardcode the license to the source file `schema.json`
- Fix the license error in production because of using the hardcoded development key
- Allow different license keys in different environments

For verifying it, I've published a fork `@jeff-tian/strapi-plugin-ckeditor`, which works as expected.

![image](https://github.com/user-attachments/assets/247043b7-1aaf-4ae8-a393-a49edd13e60c)

## Server Config

Add a `CKEDITOR_LICENSE_KEY` to the environment variable to allow the client side to load:

![image](https://github.com/user-attachments/assets/c264ba0d-c7d7-47ba-b5f3-f184b1798c8a)
